### PR TITLE
Fix metrix decrement (Issue 5)

### DIFF
--- a/lib/adapter/metrix.ex
+++ b/lib/adapter/metrix.ex
@@ -35,7 +35,7 @@ defmodule Rheostat.Adapter.Metrix do
   end
 
   def decrement(key, val \\ 1, options \\ []) when is_number(val) do
-    count(key, val, options)
+    count(metadata(options), key, -val)
     :ok
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Rheostat.MixProject do
   def project do
     [
       app: :rheostat,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),


### PR DESCRIPTION
`Rheostat.Adapter.Metrix.decrement` was passing the wrong arguments to `count`.

This commit changes it to pass the right arguments to `count`.

[Issue 5](https://github.com/spreedly/rheostat/issues/5)